### PR TITLE
don't 'use Moo::Role' in main plugin for compat with next Dancer2 release

### DIFF
--- a/lib/Dancer2/Plugin/Shutdown/Redis.pm
+++ b/lib/Dancer2/Plugin/Shutdown/Redis.pm
@@ -9,7 +9,6 @@ use Scalar::Util qw(blessed);
 use Redis;
 use Carp qw(croak);
 use Tie::Redis::Candy 1.001 qw(redis_hash);
-use Moo::Role 2;
 with 'Dancer2::Plugin::Role::Shutdown';
 
 # VERSION


### PR DESCRIPTION
In the next Dancer2 release the plugin system has been completely
overhauled and plugins are now Moo classes so trying to use
Moo::Role in a plugin is a fail.
